### PR TITLE
Mark per-player game options dirty when subroles change (fix AddWatch sync)

### DIFF
--- a/Modules/GameState.cs
+++ b/Modules/GameState.cs
@@ -5,6 +5,7 @@ using AmongUs.GameOptions;
 using HarmonyLib;
 
 using TownOfHostY.Attributes;
+using TownOfHostY.Modules;
 using TownOfHostY.Roles.Core;
 
 namespace TownOfHostY;
@@ -94,19 +95,26 @@ public class PlayerState
     }
     public void SetSubRole(CustomRoles role, bool AllReplace = false)
     {
-        if (AllReplace)
+        if (AllReplace && SubRoles.Count > 0)
+        {
             SubRoles.ToArray().Do(role => SubRoles.Remove(role));
+            PlayerGameOptionsSender.SetDirty(PlayerId);
+        }
 
         if (!SubRoles.Contains(role))
         {
             SubRoles.Add(role);
             CustomRoleManager.SubRoleAdd(PlayerId, role);
+            PlayerGameOptionsSender.SetDirty(PlayerId);
         }
     }
     public void RemoveSubRole(CustomRoles role)
     {
         if (SubRoles.Contains(role))
+        {
             SubRoles.Remove(role);
+            PlayerGameOptionsSender.SetDirty(PlayerId);
+        }
     }
 
     public void SetDead()


### PR DESCRIPTION
### Motivation
- Addon/subrole effects (e.g. `AddWatch`) are applied via per-player game option payloads but the server did not always re-send options when a player's subroles changed, causing capabilities to be missing or to remain on the wrong player.

### Description
- Added `using TownOfHostY.Modules;` to `Modules/GameState.cs` and call `PlayerGameOptionsSender.SetDirty(PlayerId)` when subroles are replaced via `AllReplace` so player options are re-sent after clearing.
- Call `PlayerGameOptionsSender.SetDirty(PlayerId)` right after adding a new subrole in `SetSubRole` so the newly-added addon takes effect immediately for that player.
- Call `PlayerGameOptionsSender.SetDirty(PlayerId)` after removing a subrole in `RemoveSubRole` so removed addon effects are removed from that player's per-player options.
- Guard `AllReplace` handling with `SubRoles.Count > 0` to avoid unnecessary work when there is nothing to remove.

### Testing
- Attempted to run `dotnet build -v minimal` but the environment lacks `dotnet`, so the build could not be executed (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e9990a588333b1189fb68afe605e)